### PR TITLE
Force loading the readline module in python.

### DIFF
--- a/languages/python2/main.go
+++ b/languages/python2/main.go
@@ -15,6 +15,7 @@ type Python struct{}
 
 func (p Python) Open() {
 	C.Py_Initialize()
+	p.LoadModule("readline")
 	p.Eval("import signal")
 	p.Eval("signal.signal(signal.SIGINT, signal.default_int_handler)")
 }

--- a/languages/python3/main.go
+++ b/languages/python3/main.go
@@ -16,6 +16,7 @@ type Python struct{}
 
 func (p Python) Open() {
 	C.Py_Initialize()
+	p.LoadModule("readline")
 	p.Eval("import signal")
 	p.Eval("signal.signal(signal.SIGINT, signal.default_int_handler)")
 }
@@ -58,6 +59,12 @@ func (p Python) REPLLikeEval(code string) {
 	ccode := C.CString(code)
 	defer C.free(unsafe.Pointer(ccode))
 	C.pry_eval(ccode, C.Py_single_input)
+}
+
+func (p Python) LoadModule(mod string) {
+	cmode := C.CString(mod)
+	defer C.free(unsafe.Pointer(cmode))
+	C.PyImport_ImportModule(cmode)
 }
 
 func (p Python) REPL() {


### PR DESCRIPTION
This makes program exectuion more closely mirror exectuion in the repl.

Also it makes input/raw_input works as documented where the propt is written
to stdout.