### PR TITLE
Add eval-file behavior for OCaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Usage of ./prybar-language:
 | Javascript (spidermonkey) | ✔    | ✗               | ✗         | ✗    | ✗              | -          |
 | Javascript (nodejs)       | ✔    | ✔               | ✔         | ✔    | ✔              | ✔          |
 | Julia                     | ✔    | ✗               | ✔         | ✔    | ✗              | ✔          |
-| OCaml                     | ✔    | ✔               | ✗         | ✔    | ✗              | ✔          |
+| OCaml                     | ✔    | ✔               | ✔         | ✔    | ✗              | ✔          |
 
 ## Building
 

--- a/languages/ocaml/repl.ml
+++ b/languages/ocaml/repl.ml
@@ -45,9 +45,6 @@ let _ =
     run_mode := true ;
     code := str
   in
-  let interactive_mode_arg str =
-    interactive_mode := true ;
-  in
   let speclist =
     [ ("-q", Arg.Set quiet, "Don't print OCaml version on startup")
     ; ( "-e" , Arg.String print_mode_arg , "Eval and output results of interpreted code" )

--- a/languages/ocaml/repl.ml
+++ b/languages/ocaml/repl.ml
@@ -114,10 +114,6 @@ let _ =
       use_silently ppf explicit_name
 
     let loop ppf =
-      (* If there's an entry file provided, run it before dropping into interactive mode *)
-      (match !eval_filepath with
-      | Some name -> run_script ppf name 
-      | _ -> false) |> ignore ; 
       Clflags.debug := true ;
       Location.formatter_for_warnings := ppf ;
       ( try initialize_toplevel_env () with
@@ -130,6 +126,12 @@ let _ =
       Location.input_lexbuf := Some lb ;
       Sys.catch_break true ;
       (*load_ocamlinit ppf;*)
+
+      (* If there's an entry file provided, run it before dropping into interactive mode *)
+      (match !eval_filepath with
+      | Some name -> run_script ppf name 
+      | _ -> false) |> ignore ; 
+
       while true do
         let snap = Btype.snapshot () in
         try


### PR DESCRIPTION
Enables following:

```ml
(* test.ml *)
let a = 1 + 1;;
print_endline "Loaded";;
```

Running it:

```sh
./prybar-ocaml -i test.ml
```

Some example interaction:

```
OCaml 4.07.0 on Unix
Loaded
-->  a;;
- : int = 2
-->
```

Note how the `a` binding is available in the interactive session.