### PR TITLE
Remove 'signal' from scope for python

### DIFF
--- a/languages/python3/main.go
+++ b/languages/python3/main.go
@@ -21,6 +21,7 @@ func (p Python) Open() {
 	p.loadModule("readline")
 	p.Eval("import signal")
 	p.Eval("signal.signal(signal.SIGINT, signal.default_int_handler)")
+	p.Eval("del signal")
 }
 
 func (p Python) Version() string {


### PR DESCRIPTION
See https://github.com/replit/prybar/pull/6#pullrequestreview-175641157

Tested that `./prybar-python3 -i` now gives `NameError` for `signal`, but I can still `import` the module without error.