### PR TITLE
Improvements for Emacs Lisp

### DIFF
--- a/prybar_assets/elisp/repl.el
+++ b/prybar_assets/elisp/repl.el
@@ -48,13 +48,10 @@ expands to:
 The REPL uses `ielm', which see. After version information is
 printed and forms for immediate evaluation or execution are
 handled, display the IELM buffer and return."
+  ;; For some reason in the repl.it environment the text all gets
+  ;; underlined sometimes. Redisplaying fixes this.
+  (redisplay)
   (menu-bar-mode -1)
-  ;; Disable bold and underline, from
-  ;; <https://stackoverflow.com/a/2065305/3538165>.
-  (mapc
-   (lambda (face)
-     (set-face-attribute face nil :weight 'normal :underline nil))
-   (face-list))
   ;; Make it so you can `load' or `require' files from the project
   ;; directory.
   (add-to-list 'load-path default-directory)

--- a/prybar_assets/elisp/repl.el
+++ b/prybar_assets/elisp/repl.el
@@ -55,6 +55,9 @@ handled, display the IELM buffer and return."
    (lambda (face)
      (set-face-attribute face nil :weight 'normal :underline nil))
    (face-list))
+  ;; Make it so you can `load' or `require' files from the project
+  ;; directory.
+  (add-to-list 'load-path default-directory)
   ;; IELM only supports PS1, not PS2.
   (with-prybar-config
       (eval exec (ps1 "--> ") quiet file)


### PR DESCRIPTION
* Add project directory to `load-path`, so you can `require` the files in it.
* Redisplay when starting Emacs, which fixes both C-a/C-e malfunctions and also all the text sometimes getting underlined for no discernible reason.