### PR TITLE
Improve developer experience with Docker

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,10 +4,8 @@ COPY scripts/docker-install.sh /tmp/docker-install.sh
 RUN /tmp/docker-install.sh
 
 RUN mkdir -p /gocode/src/github.com/replit/prybar
-COPY . /gocode/src/github.com/replit/prybar
 WORKDIR /gocode/src/github.com/replit/prybar
 
 ENV GOPATH=/gocode LC_ALL=C.UTF-8 PATH="/gocode/src/github.com/replit/prybar:$PATH"
 
-RUN cp languages/tcl/tcl.pc /usr/lib/pkgconfig/
-RUN make
+RUN ln -s "$PWD/languages/tcl/tcl.pc" /usr/lib/pkgconfig/

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,37 @@
-LANGDIR := ./languages
-LANGS   := $(shell ls $(LANGDIR))
-BINS    := $(addprefix prybar-,$(LANGS))
+.PHONY: all
+all: $(addprefix prybar-,$(filter-out R,$(shell ls languages))) ## Build all Prybar binaries
 
-.PHONY: clean test all
+# Avoid depending on the subdirectories of 'languages', because their
+# mtimes are updated every time we build.
+prybar-%: utils/*.go languages/%/* ## Build the Prybar binary for LANG
+	@echo "build prybar-$(*)"
+	@scripts/inject.sh $(*)
+	@go generate languages/$(*)/main.go
+	@go build -o prybar-$(*) ./languages/$(*)
+	@rm -f languages/$(*)/generated_*.go
 
-all: $(BINS)
+.PHONY: docker
+docker: ## Run a shell with Prybar inside Docker
+	docker build . -f Dockerfile.dev -t prybar-dev
+	docker run -it --rm -v "$$PWD:/gocode/src/github.com/replit/prybar" prybar-dev
 
-prybar-%: ./languages/$(*) ./utils/* ./languages/$(*)/*
-	./scripts/inject.sh $(*)
-	go generate ./languages/$(*)/main.go
-	go build -o prybar-$(*) ./languages/$(*)
-	rm ./languages/$(*)/generated_*.go
+.PHONY: image
+image: ## Build a Docker image with Prybar for distribution
+	docker build . -t prybar
 
-test:
+.PHONY: test
+test: ## Run integration tests
 	./run_tests
 
-clean:
-	@rm -f ./prybar-* ./languages/*/generated_*.go
+.PHONY: clean
+clean: ## Remove build artifacts
+	rm -f prybar-* languages/*/generated_*.go
+
+.PHONY: help
+help: ## Show this message
+	@echo "usage:" >&2
+	@grep -h "[#]# " $(MAKEFILE_LIST)	| \
+		sed 's/^/  make /'		| \
+		sed 's/:[^#]*[#]# /|/'		| \
+		sed 's/%/LANG/'			| \
+		column -t -s'|' >&2

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ wanted them to all behave the same: run code and drop into a REPL!
 
 ## How it works
 
-Prybar, written in Golang, maintains a common command-line interface
-that calls into a select language backend. When possible, the language
-backends are implemented using cgo and the language's C-bindings.
-Otherwise, they make use of a small script written in the host
-language which starts a Prybar-compatible REPL.
+Prybar, written in [Golang](https://golang.org/), maintains a common
+command-line interface that calls into a select language backend. When
+possible, the language backends are implemented using cgo and the
+language's C-bindings. Otherwise, they make use of a small script
+written in the host language which starts a Prybar-compatible REPL.
 
 ## Usage
 
@@ -50,34 +50,47 @@ language which starts a Prybar-compatible REPL.
 
 ## Build and run
 
+    % make help
+    usage:
+      make all          Build all Prybar binaries
+      make prybar-LANG  Build the Prybar binary for LANG
+      make docker       Run a shell with Prybar inside Docker
+      make image        Build a Docker image with Prybar for distribution
+      make test         Run integration tests
+      make clean        Remove build artifacts
+      make help         Show this message
+
 Prybar uses Docker to make it easy to get started with development.
 First, you must [install Docker](https://docs.docker.com/install/).
 Then, run:
 
-    $ docker build . -t prybar
+    $ make docker
 
 to create a Docker image containing the Prybar code and all of its
-dependencies. Building the image also includes compiling the Prybar
-binaries (there is one for each supported language).
+dependencies, and launch a shell inside of it. The Prybar source
+repository will be synchronized with the working directory of the
+container's filesystem, so you only need to re-run `make docker` if
+you change the Dockerfile or any of its scripts.
 
-To run the code in a Docker container:
+To build Prybar (this should be done inside `make docker` unless you
+have installed all of Prybar's dependencies on your system), run
+`make` or `make all`. Then the `prybar-LANG` binaries will be
+available in the working directory and on `$PATH`, one for each
+supported language `LANG` ([see the `languages` subdirectory of this
+repository](languages)):
 
-    $ docker run --rm -it prybar
-    # ./prybar-python3 -h
-
-The directory contains one `./prybar-LANG` binary for each supported
-language `LANG` ([see the `languages` subdirectory of this
-repository](languages)).
-
-When you make changes to the code, you must re-run `docker build` to
-create a new Docker image before you can run it with `docker run`.
+    $ prybar-python3 -h
 
 ### Distribution
 
-The script `./extract.sh` can be used to compile and produce a tarball
-containing all the Prybar binaries. You can run it on its own; it will
-automatically compile a new Docker image if necessary and extract the
-binaries from a running container.
+Run `make image` to create a Docker image containing not only Prybar's
+dependencies and source code but also its compiled binaries, which can
+be embedded inside other Docker images by means of `COPY
+--from=basicer/prybar`.
+
+This image is automatically built and deployed to [Docker
+Hub](https://hub.docker.com/) every time a commit is merged to
+`master`.
 
 ## License
 

--- a/extract.sh
+++ b/extract.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-docker build -t prybar .
-docker run prybar bash -c 'tar -zc prybar-*' > prybar.tar.gz

--- a/languages/R/main.go
+++ b/languages/R/main.go
@@ -3,7 +3,7 @@ package main
 // USING_CGO
 
 /*
-#cgo pkg-config: libr
+#cgo pkg-config: libR
 #include <stdlib.h>
 #include <Rembedded.h>
 #include <RVersion.h>

--- a/scripts/docker-install.sh
+++ b/scripts/docker-install.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y software-properties-common
+add-apt-repository ppa:avsm/ppa
+
+packages="
+
+bsdmainutils
+build-essential
+emacs-nox
+expect
+golang
+libffi-dev
+liblua5.1-dev
+libnspr4-dev
+libreadline-dev
+m4
+nodejs
+ocaml
+opam
+python-dev
+python3-dev
+ruby2.5-dev
+tcl-dev
+wget
+
+"
+
+apt-get install -y $packages
+rm -rf /var/lib/apt/lists/*
+
+wget -nv https://launchpadlibrarian.net/309343863/libmozjs185-1.0_1.8.5-1.0.0+dfsg-7_amd64.deb
+wget -nv https://launchpadlibrarian.net/309343864/libmozjs185-dev_1.8.5-1.0.0+dfsg-7_amd64.deb
+dpkg -i libmozjs185*.deb
+rm libmozjs185*.deb
+
+wget https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1.0-linux-x86_64.tar.gz
+tar -xf julia-1.1.0-linux-x86_64.tar.gz
+cp -R   julia-1.1.0/bin/* /usr/bin/
+cp -R   julia-1.1.0/include/* /usr/include/
+cp -R   julia-1.1.0/lib/* /usr/lib/
+cp -R   julia-1.1.0/share/* /usr/share/
+rm -rf  julia-1.1.0*
+
+opam init -c ocaml-system -n --disable-sandboxing
+cat <<"EOF" >> "$HOME/.bashrc"
+export OPAMROOTISOK=1
+eval "$(opam env)"
+EOF
+
+rm /tmp/docker-install.sh

--- a/scripts/inject.sh
+++ b/scripts/inject.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-if grep "USING_CGO"  ./languages/$1/main.go; then
+if grep -q "USING_CGO"  ./languages/$1/main.go; then
 	cp inject_claunch.go ./languages/$1/generated_launch.go
 else
 	cp inject_elaunch.go ./languages/$1/generated_launch.go
 fi
-
-
-


### PR DESCRIPTION
* Fix "Running as root is not recommended" message at container startup. See <https://github.com/ocaml/opam/issues/2575>.
* Add Makefile targets to build and run Docker images, and 'make help' target.
* Reduce number of layers in Dockerfile and improve build time.
* Fix several bugs in Makefile which were causing spurious rebuilds.
* Remove legacy extract.sh script.
* Use HTTPS when downloading libmozjs.
* Improve readability of Dockerfile and Makefile. Split out dependency installation into a separate Bash script.
* Reduce verbosity of application and Docker builds.
* Fix mistake in Cgo configuration for R, although R is still broken because using Cgo with libR requires Go 1.10.5 while Ubuntu Bionic only ships 1.10.4. See <https://github.com/golang/go/issues/27496>.