### PR TITLE
Start Emacs with -nw argument; upgrade from 25 to 26

### DIFF
--- a/languages/elisp/main.go
+++ b/languages/elisp/main.go
@@ -52,7 +52,7 @@ func Execute(config *utils.Config) {
 		fmt.Fprintln(os.Stderr, "prybar-elisp: warn: ps2 not implemented");
 	}
 
-	args := []string{"emacs", "-Q", "--load", replPath, "--eval", "(prybar-repl)"}
+	args := []string{"emacs", "-nw", "-Q", "--load", replPath, "--eval", "(prybar-repl)"}
 	err = syscall.Exec(emacs, args, os.Environ())
 
 	if err != nil {

--- a/scripts/docker-install.sh
+++ b/scripts/docker-install.sh
@@ -8,12 +8,13 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y software-properties-common
 add-apt-repository ppa:avsm/ppa
+add-apt-repository ppa:kelleyk/emacs
 
 packages="
 
 bsdmainutils
 build-essential
-emacs-nox
+emacs26
 expect
 golang
 libffi-dev


### PR DESCRIPTION
Using `-nw` is necessary if we want to support Emacs 26 from the kelleyk PPA, which is compiled with graphical support and therefore gets tangled up with our X11 support on Repl.it.