### PR TITLE
Update base image from Bionic to Disco

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 plugins/
 prybar-*
+prybar_assets/sqlite/patch.so
 deps.lst
 prybar.tar.gz
 generated_*.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:disco
 
 COPY scripts/docker-install.sh /tmp/docker-install.sh
 RUN /tmp/docker-install.sh

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:disco
 
 COPY scripts/docker-install.sh /tmp/docker-install.sh
 RUN /tmp/docker-install.sh

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test: ## Run integration tests
 
 .PHONY: clean
 clean: ## Remove build artifacts
-	rm -f prybar-* languages/*/generated_*.go
+	rm -f prybar-* languages/*/generated_*.go prybar_assets/sqlite/patch.so
 
 .PHONY: help
 help: ## Show this message

--- a/languages/julia/main.go
+++ b/languages/julia/main.go
@@ -3,7 +3,7 @@ package main
 // USING_CGO
 
 /*
-#cgo CFLAGS: -I/usr/include/julia
+#cgo CFLAGS: -I/usr/local/include/julia
 #cgo LDFLAGS: -ljulia
 #include "pry.h"
 */

--- a/languages/sqlite/compile
+++ b/languages/sqlite/compile
@@ -1,6 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-COMPILE_DIR=$(dirname "$0")
-DEST_DIR=$COMPILE_DIR/../../prybar_assets/sqlite
-mkdir $DEST_DIR
-gcc -Wall -shared -fPIC -ldl -o $DEST_DIR/patch.so $COMPILE_DIR/patch/patch.c
+set -e
+set -o pipefail
+
+COMPILE_DIR="$(dirname "$0")"
+DEST_DIR="$COMPILE_DIR/../../prybar_assets/sqlite"
+mkdir -p "$DEST_DIR"
+gcc -Wall -shared -fPIC -ldl -o "$DEST_DIR/patch.so" "$COMPILE_DIR/patch/patch.c"

--- a/scripts/docker-install.sh
+++ b/scripts/docker-install.sh
@@ -3,57 +3,59 @@
 set -e
 set -o pipefail
 
-export DEBIAN_FRONTEND=noninteractive
-
-apt-get update
-apt-get install -y software-properties-common
-add-apt-repository ppa:avsm/ppa
-add-apt-repository ppa:kelleyk/emacs
+cd /tmp
 
 packages="
 
-bsdmainutils
-build-essential
-emacs26
-expect
-golang
-libffi-dev
+# languages
+emacs-nox
 liblua5.1-dev
-libnspr4-dev
-libreadline-dev
-m4
 nodejs
 ocaml
-opam
 python-dev
 python3-dev
-ruby2.5-dev
+ruby-dev
 sqlite3
 tcl-dev
+
+# build and test
+bsdmainutils
+build-essential
+expect
+golang
+
+# things we link against
+libreadline-dev
+
+# needed for the version of libmozjs that we download
+libffi-dev
+libnspr4-dev
+
+# used during installation
 wget
 
 "
 
-apt-get install -y $packages
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y $(grep -v "^#" <<< "$packages")
 rm -rf /var/lib/apt/lists/*
 
+# The version in the Disco repos is out of date (1.0 series) and does
+# not expose the API we need.
+wget -nv https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1.1-linux-x86_64.tar.gz
+tar -xf *.tar.gz
+cp -R   julia-*/bin/*     /usr/local/bin/
+cp -R   julia-*/include/* /usr/local/include/
+cp -R   julia-*/lib/*     /usr/local/lib/
+cp -R   julia-*/share/*   /usr/local/share/
+rm -rf  julia-*
+
+# The version in the Disco repos is not compatible with cgo ("invalid
+# flag in pkg-config --cflags: -include").
 wget -nv https://launchpadlibrarian.net/309343863/libmozjs185-1.0_1.8.5-1.0.0+dfsg-7_amd64.deb
 wget -nv https://launchpadlibrarian.net/309343864/libmozjs185-dev_1.8.5-1.0.0+dfsg-7_amd64.deb
-dpkg -i libmozjs185*.deb
-rm libmozjs185*.deb
-
-wget https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1.0-linux-x86_64.tar.gz
-tar -xf julia-1.1.0-linux-x86_64.tar.gz
-cp -R   julia-1.1.0/bin/* /usr/bin/
-cp -R   julia-1.1.0/include/* /usr/include/
-cp -R   julia-1.1.0/lib/* /usr/lib/
-cp -R   julia-1.1.0/share/* /usr/share/
-rm -rf  julia-1.1.0*
-
-opam init -c ocaml-system -n --disable-sandboxing
-cat <<"EOF" >> "$HOME/.bashrc"
-export OPAMROOTISOK=1
-eval "$(opam env)"
-EOF
+dpkg -i *.deb
+rm *.deb
 
 rm /tmp/docker-install.sh

--- a/tests/julia/header.exp
+++ b/tests/julia/header.exp
@@ -3,7 +3,7 @@
 set timeout -1
 spawn ./prybar-julia -i
 match_max 100000
-expect -exact "Version 1.1.0 (2019-01-21)"
+expect -exact "Version 1.1.1 (2019-05-16)"
 expect -exact "--> \[0m\[0m\r\[4C\r\[4C"
 send -- ""
 expect eof

--- a/tests/sqlite/header.exp
+++ b/tests/sqlite/header.exp
@@ -1,4 +1,4 @@
 #!/usr/bin/expect -f
 
 spawn ./prybar-sqlite -i
-expect -gl "-- Loading resources from /tmp/sqlite-config*\r\nSQLite version 3.22.0*\r\nEnter \".help\" for usage hints.\r\n--> "
+expect -gl "-- Loading resources from /tmp/sqlite-config*\r\nSQLite version 3.27.2*\r\nEnter \".help\" for usage hints.\r\n--> "


### PR DESCRIPTION
This is needed for Python 3.7, which we are upgrading Repl.it to use. Also:

* Install Emacs 26 from official repos instead of PPA.
* Install Julia to /usr/local instead of /usr, and upgrade from 1.1.0 to 1.1.1.
* No longer install m4 and opam.
* Add explanatory comments to Docker install script.