### PR TITLE
prybar-elisp: Automatically use Cask if available

### DIFF
--- a/scripts/docker-install.sh
+++ b/scripts/docker-install.sh
@@ -32,6 +32,7 @@ libffi-dev
 libnspr4-dev
 
 # used during installation
+git
 wget
 
 "
@@ -57,5 +58,12 @@ wget -nv https://launchpadlibrarian.net/309343863/libmozjs185-1.0_1.8.5-1.0.0+df
 wget -nv https://launchpadlibrarian.net/309343864/libmozjs185-dev_1.8.5-1.0.0+dfsg-7_amd64.deb
 dpkg -i *.deb
 rm *.deb
+
+# prybar-elisp has support for automatically running inside a Cask
+# environment if there is a Cask file in the working directory. Might
+# as well install Cask so it's easy to test.
+git clone https://github.com/cask/cask.git /usr/local/cask
+ln -s /usr/local/cask/bin/cask /usr/local/bin/cask
+cask upgrade-cask
 
 rm /tmp/docker-install.sh


### PR DESCRIPTION
* If a file named `Cask` exists, and a command named `cask` is on the `$PATH`, then use `cask exec` to make the Cask dependencies available in the repl. This will be good for interop with UPM / packager3.
* Also, this was literally the first Go code I ever wrote, so I did some cleanup on it.