### PR TITLE
Add lisp/ subdirectory to load-path

### DIFF
--- a/prybar_assets/elisp/repl.el
+++ b/prybar_assets/elisp/repl.el
@@ -53,8 +53,10 @@ handled, display the IELM buffer and return."
   (redisplay)
   (menu-bar-mode -1)
   ;; Make it so you can `load' or `require' files from the project
-  ;; directory.
+  ;; directory, and any lisp/ subdirectory (often seen in larger
+  ;; projects).
   (add-to-list 'load-path default-directory)
+  (add-to-list 'load-path (expand-file-name "lisp" default-directory))
   ;; IELM only supports PS1, not PS2.
   (with-prybar-config
       (eval exec (ps1 "--> ") quiet file)


### PR DESCRIPTION
This means you can import https://github.com/magit/magit into Repl.it and just be able to `(require 'magit)`, for example. Many large Elisp projects use a `lisp/` subdirectory.