### PR TITLE
Display error message when running a Tcl file

### DIFF
--- a/languages/tcl/main.go
+++ b/languages/tcl/main.go
@@ -67,7 +67,12 @@ func (p *Tcl) EvalFile(file string, args []string) {
 	cfile := C.CString(file)
 	defer C.free(unsafe.Pointer(cfile))
 
-	C.Tcl_EvalFile(p.interp, cfile)
+	status := C.Tcl_EvalFile(p.interp, cfile)
+
+	if status != C.TCL_OK {
+		errstr := C.GoString(C.Tcl_GetStringResult(p.interp))
+		fmt.Fprintf(os.Stderr, "error: %s\n", errstr)
+	}
 }
 
 func (p *Tcl) Eval(code string) {

--- a/tests/tcl/invalid_command.exp
+++ b/tests/tcl/invalid_command.exp
@@ -1,0 +1,7 @@
+#!/usr/bin/expect -f
+
+set timeout -1
+spawn ./prybar-tcl -q -i ./test-files/hi_julia.jl
+match_max 100000
+
+expect -exact "error: invalid command name \"my_number\"\r"


### PR DESCRIPTION
In theory, this change should allow error messages to be displayed when they occur when running a Tcl repl.