### PR TITLE
Use Python 3.8

### DIFF
--- a/languages/python3/main.go
+++ b/languages/python3/main.go
@@ -3,9 +3,8 @@ package main
 // USING_CGO
 
 /*
-#cgo pkg-config: python3
+#cgo pkg-config: python-3.8-embed
 #include "pry_python3.h"
-
 */
 import "C"
 

--- a/scripts/docker-install.sh
+++ b/scripts/docker-install.sh
@@ -14,10 +14,13 @@ liblua5.1-dev
 nodejs
 ocaml
 python-dev
-python3-dev
 ruby-dev
 sqlite3
 tcl-dev
+
+# install the same version of Python in this image that we intend to use with
+# Python in prod, since Prybar is dynamically linked.
+python3.8-dev
 
 # build and test
 bsdmainutils


### PR DESCRIPTION
`prybar-python3` should link against Python 3.8 so that we can move to 3.8 on Repl.it.

There was a little gotcha in 3.8 (https://docs.python.org/3.8/whatsnew/3.8.html#debug-build-uses-the-same-abi-as-release-build) which is why I had to change the cgo flag: 
> Add a pkg-config `python-3.8-embed` module to embed Python into an application