### PR TITLE
install julia under /usr instead of /usr/local

### DIFF
--- a/languages/julia/main.go
+++ b/languages/julia/main.go
@@ -3,7 +3,7 @@ package main
 // USING_CGO
 
 /*
-#cgo CFLAGS: -I/usr/local/include/julia
+#cgo CFLAGS: -I/usr/include/julia
 #cgo LDFLAGS: -ljulia
 #include "pry.h"
 */

--- a/scripts/docker-install.sh
+++ b/scripts/docker-install.sh
@@ -59,10 +59,10 @@ chmod +x "linux-install-${clojure_version}.sh"
 # not expose the API we need.
 wget -nv https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3.1-linux-x86_64.tar.gz
 tar -xf *.tar.gz
-cp -R   julia-*/bin/*     /usr/local/bin/
-cp -R   julia-*/include/* /usr/local/include/
-cp -R   julia-*/lib/*     /usr/local/lib/
-cp -R   julia-*/share/*   /usr/local/share/
+cp -R   julia-*/bin/*     /usr/bin/
+cp -R   julia-*/include/* /usr/include/
+cp -R   julia-*/lib/*     /usr/lib/
+cp -R   julia-*/share/*   /usr/share/
 rm -rf  julia-*
 
 # The version in the Disco repos is not compatible with cgo ("invalid


### PR DESCRIPTION
Polygott currently installs julia under `/usr`, not `/usr/local`. I'm changing prybar to match polygott so `prybar-julia` can find the julia shared libraries.

For whatever reason, even if I make both polygott and prybar install julia under `/usr/local`, `prybar-julia` cannot find `libjulia.so` at runtime.