### PR TITLE
Push git tag on successful build of master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "dd:6f:07:f7:7e:b0:ab:07:1c:1a:43:ba:a0:a3:b9:6f"
+      - run: echo << pipeline.number >>
       - run: apk add --no-cache --no-progress make git openssh
       - run:
           name: Keyscan Github (HACK) #https://discuss.circleci.com/t/known-hosts-in-circle-2-0/18544

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,12 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "dd:6f:07:f7:7e:b0:ab:07:1c:1a:43:ba:a0:a3:b9:6f"
-      - checkout
-      - setup_remote_docker
       - run: apk add --no-cache --no-progress make git openssh
       - run:
           name: Keyscan Github (HACK) #https://discuss.circleci.com/t/known-hosts-in-circle-2-0/18544
           command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - checkout
+      - setup_remote_docker
       - run: git tag "circleci_build_${CIRCLE_BUILD_NUM}"
       - run: git push origin "circleci_build_${CIRCLE_BUILD_NUM}"
       - run: make test-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ jobs:
           name: Keyscan Github (HACK) #https://discuss.circleci.com/t/known-hosts-in-circle-2-0/18544
           command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - checkout
-      - run: git tag "circleci_job_${CIRCLE_JOB}_build_${CIRCLE_BUILD_NUM}"
-      - run: git push origin "circleci_job_${CIRCLE_JOB}_build_${CIRCLE_BUILD_NUM}"
+      - run: git tag "circleci_pipeline_<< pipeline.id >>_build_${CIRCLE_BUILD_NUM}"
+      - run: git push origin "circleci_pipeline_<< pipeline.id >>_build_${CIRCLE_BUILD_NUM}"
       - setup_remote_docker
       - run: make test-image
   build_test_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,12 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: apk add --no-cache --no-progress make git openssh
-      - run: make test-image
       - run: git tag "circleci_build_${CIRCLE_BUILD_NUM}"
       - run: git push origin "circleci_build_${CIRCLE_BUILD_NUM}"
+      - run:
+          name: Keyscan Github (HACK) #https://discuss.circleci.com/t/known-hosts-in-circle-2-0/18544
+          command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - run: make test-image
   build_test_and_deploy:
     docker:
       - image: docker:18.09

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,11 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: apk add --no-cache --no-progress make git openssh
-      - run: git tag "circleci_build_${CIRCLE_BUILD_NUM}"
-      - run: git push origin "circleci_build_${CIRCLE_BUILD_NUM}"
       - run:
           name: Keyscan Github (HACK) #https://discuss.circleci.com/t/known-hosts-in-circle-2-0/18544
           command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+      - run: git tag "circleci_build_${CIRCLE_BUILD_NUM}"
+      - run: git push origin "circleci_build_${CIRCLE_BUILD_NUM}"
       - run: make test-image
   build_test_and_deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ jobs:
           name: Keyscan Github (HACK) #https://discuss.circleci.com/t/known-hosts-in-circle-2-0/18544
           command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - checkout
-      - run: git tag "circleci_pipeline_<< pipeline.id >>_build_${CIRCLE_BUILD_NUM}"
-      - run: git push origin "circleci_pipeline_<< pipeline.id >>_build_${CIRCLE_BUILD_NUM}"
+      - run: git tag "circleci_pipeline_<< pipeline.number >>_build_${CIRCLE_BUILD_NUM}"
+      - run: git push origin "circleci_pipeline_<< pipeline.number >>_build_${CIRCLE_BUILD_NUM}"
       - setup_remote_docker
       - run: make test-image
   build_test_and_deploy:
@@ -36,8 +36,8 @@ jobs:
             echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
             docker tag prybar:latest replco/prybar:latest
             docker push replco/prybar:latest
-            git tag "circleci_job_${CIRCLE_JOB}_build_${CIRCLE_BUILD_NUM}"
-            git push origin "circleci_job_${CIRCLE_JOB}_build_${CIRCLE_BUILD_NUM}"
+            git tag "circleci_job_<< pipeline.number >>_build_${CIRCLE_BUILD_NUM}"
+            git push origin "circleci_job_<< pipeline.number >>_build_${CIRCLE_BUILD_NUM}"
 
 workflows:
   ci:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "37:92:31:a7:d9:3f:f0:ba:2a:97:84:e6:5f:a0:0b:68"
+            - "dd:6f:07:f7:7e:b0:ab:07:1c:1a:43:ba:a0:a3:b9:6f"
       - checkout
       - setup_remote_docker
       - run: apk add --no-cache --no-progress make git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ jobs:
     docker:
       - image: docker:18.09
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "37:92:31:a7:d9:3f:f0:ba:2a:97:84:e6:5f:a0:0b:68"
       - checkout
       - setup_remote_docker
       - run: apk add --no-cache --no-progress make git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       - setup_remote_docker
       - run: apk add --no-cache --no-progress make
       - run: make test-image
+      - run: git tag "circleci_build_${CIRCLE_BUILD_NUM}"
   build_test_and_deploy:
     docker:
       - image: docker:18.09

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,23 +12,32 @@ jobs:
           name: Keyscan Github (HACK) #https://discuss.circleci.com/t/known-hosts-in-circle-2-0/18544
           command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - checkout
+      - run: git tag "circleci_job_${CIRCLE_JOB}_build_${CIRCLE_BUILD_NUM}"
+      - run: git push origin "circleci_job_${CIRCLE_JOB}_build_${CIRCLE_BUILD_NUM}"
       - setup_remote_docker
-      - run: git tag "circleci_build_${CIRCLE_BUILD_NUM}"
-      - run: git push origin "circleci_build_${CIRCLE_BUILD_NUM}"
       - run: make test-image
   build_test_and_deploy:
     docker:
       - image: docker:18.09
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "dd:6f:07:f7:7e:b0:ab:07:1c:1a:43:ba:a0:a3:b9:6f"
+      - run: apk add --no-cache --no-progress make git openssh
+      - run:
+          name: Keyscan Github (HACK) #https://discuss.circleci.com/t/known-hosts-in-circle-2-0/18544
+          command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - checkout
       - setup_remote_docker
-      - run: apk add --no-cache --no-progress make
       - run: make test-image
       - deploy:
           command: |
             echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
             docker tag prybar:latest replco/prybar:latest
             docker push replco/prybar:latest
+            git tag "circleci_job_${CIRCLE_JOB}_build_${CIRCLE_BUILD_NUM}"
+            git push origin "circleci_job_${CIRCLE_JOB}_build_${CIRCLE_BUILD_NUM}"
+
 workflows:
   ci:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,11 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "dd:6f:07:f7:7e:b0:ab:07:1c:1a:43:ba:a0:a3:b9:6f"
-      - run: echo << pipeline.number >>
       - run: apk add --no-cache --no-progress make git openssh
       - run:
           name: Keyscan Github (HACK) #https://discuss.circleci.com/t/known-hosts-in-circle-2-0/18544
           command: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
       - checkout
-      - run: git tag "circleci_pipeline_<< pipeline.number >>_build_${CIRCLE_BUILD_NUM}"
-      - run: git push origin "circleci_pipeline_<< pipeline.number >>_build_${CIRCLE_BUILD_NUM}"
       - setup_remote_docker
       - run: make test-image
   build_test_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
       - run: apk add --no-cache --no-progress make
       - run: make test-image
       - run: git tag "circleci_build_${CIRCLE_BUILD_NUM}"
+      - run: git push origin "circleci_build_${CIRCLE_BUILD_NUM}"
   build_test_and_deploy:
     docker:
       - image: docker:18.09

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
             - "dd:6f:07:f7:7e:b0:ab:07:1c:1a:43:ba:a0:a3:b9:6f"
       - checkout
       - setup_remote_docker
-      - run: apk add --no-cache --no-progress make git
+      - run: apk add --no-cache --no-progress make git openssh
       - run: make test-image
       - run: git tag "circleci_build_${CIRCLE_BUILD_NUM}"
       - run: git push origin "circleci_build_${CIRCLE_BUILD_NUM}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: apk add --no-cache --no-progress make
+      - run: apk add --no-cache --no-progress make git
       - run: make test-image
       - run: git tag "circleci_build_${CIRCLE_BUILD_NUM}"
       - run: git push origin "circleci_build_${CIRCLE_BUILD_NUM}"


### PR DESCRIPTION
Once master successfully builds, we push a tag with the project number and the build number (both increase monotonically). This allows downstream projects (mainly polygott) to depend explicitly on particular versions of prybar.