### PR TITLE
prybar-python3 honors $VIRTUAL_ENV

### DIFF
--- a/languages/python3/main.go
+++ b/languages/python3/main.go
@@ -9,9 +9,43 @@ package main
 import "C"
 
 import (
+	"fmt"
+	"os"
+	"path"
 	"strings"
 	"unsafe"
 )
+
+var programName *C.wchar_t
+
+func Py_SetProgramName(name string) error {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	newProgramName := C.Py_DecodeLocale(cname, nil)
+	if newProgramName == nil {
+		return fmt.Errorf("fail to call Py_DecodeLocale on '%s'", name)
+	}
+	C.Py_SetProgramName(newProgramName)
+
+	//no operation is performed if nil
+	C.PyMem_RawFree(unsafe.Pointer(programName))
+	programName = newProgramName
+
+	return nil
+}
+
+func init() {
+	name := "prybar-python3"
+	virtualEnv, virtualEnvSet := os.LookupEnv("VIRTUAL_ENV")
+	if virtualEnvSet {
+		name = path.Join(virtualEnv, "bin", "prybar-python3")
+	}
+	err := Py_SetProgramName(name)
+	if err != nil {
+		panic(fmt.Sprintf("cannot set prybar-python3 program name to '%s': %s", name, err))
+	}
+}
 
 type Python struct{}
 


### PR DESCRIPTION
An embedded python interpreter computes `sys.path` based on the prefix of the interpreter name: https://docs.python.org/3/c-api/init.html#c.Py_SetProgramName

To make sure `sys.path` is set correctly (and the appropriate `sitecustomize.py` is loaded if present) when a virtualenv is activated, the program name needs to start with the virtualenv path. At startup, prybar-python3 looks for the $VIRTUAL_ENV environment variable and, if present, sets the program name to $VIRTUAL_ENV/bin/prybar-python3.

Testing this path requires adding machinery to the prybar tests. I don't want to take the time to add that machinery now, but I have tested this branch in polygott and it does indeed set the correct path.