### PR TITLE
Revert "prybar-python3 honors $VIRTUAL_ENV"

### DIFF
--- a/languages/python3/main.go
+++ b/languages/python3/main.go
@@ -9,43 +9,9 @@ package main
 import "C"
 
 import (
-	"fmt"
-	"os"
-	"path"
 	"strings"
 	"unsafe"
 )
-
-var programName *C.wchar_t
-
-func Py_SetProgramName(name string) error {
-	cname := C.CString(name)
-	defer C.free(unsafe.Pointer(cname))
-
-	newProgramName := C.Py_DecodeLocale(cname, nil)
-	if newProgramName == nil {
-		return fmt.Errorf("fail to call Py_DecodeLocale on '%s'", name)
-	}
-	C.Py_SetProgramName(newProgramName)
-
-	//no operation is performed if nil
-	C.PyMem_RawFree(unsafe.Pointer(programName))
-	programName = newProgramName
-
-	return nil
-}
-
-func init() {
-	name := "prybar-python3"
-	virtualEnv, virtualEnvSet := os.LookupEnv("VIRTUAL_ENV")
-	if virtualEnvSet {
-		name = path.Join(virtualEnv, "bin", "prybar-python3")
-	}
-	err := Py_SetProgramName(name)
-	if err != nil {
-		panic(fmt.Sprintf("cannot set prybar-python3 program name to '%s': %s", name, err))
-	}
-}
 
 type Python struct{}
 


### PR DESCRIPTION
While trying to run `pip.main(['install', 'wikipedia'])` from prybar-python3, I saw the following error:

```
ERROR: Error [Errno 2] No such file or directory: '/opt/virtualenvs/python3/bin/prybar-python3' while executing command python setup.py egg_info
ERROR: Could not install packages due to an EnvironmentError: [Errno 2] No such file or directory: '/opt/virtualenvs/python3/bin/prybar-python3'
```

Backing this PR out while I cook up a fix.

Reverts replit/prybar#53