### PR TITLE
prybar-python3 honors $VIRTUAL_ENV

### DIFF
--- a/languages/python3/main.go
+++ b/languages/python3/main.go
@@ -36,10 +36,10 @@ func Py_SetProgramName(name string) error {
 }
 
 func init() {
-	name := "prybar-python3"
+	name := "python"
 	virtualEnv, virtualEnvSet := os.LookupEnv("VIRTUAL_ENV")
 	if virtualEnvSet {
-		name = path.Join(virtualEnv, "bin", "prybar-python3")
+		name = path.Join(virtualEnv, "bin", "python")
 	}
 	err := Py_SetProgramName(name)
 	if err != nil {

--- a/languages/python3/main.go
+++ b/languages/python3/main.go
@@ -9,9 +9,43 @@ package main
 import "C"
 
 import (
+	"fmt"
+	"os"
+	"path"
 	"strings"
 	"unsafe"
 )
+
+var programName *C.wchar_t
+
+func Py_SetProgramName(name string) error {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	newProgramName := C.Py_DecodeLocale(cname, nil)
+	if newProgramName == nil {
+		return fmt.Errorf("fail to call Py_DecodeLocale on '%s'", name)
+	}
+	C.Py_SetProgramName(newProgramName)
+
+	//no operation is performed if nil
+	C.PyMem_RawFree(unsafe.Pointer(programName))
+	programName = newProgramName
+
+	return nil
+}
+
+func init() {
+	name := "prybar-python3"
+	virtualEnv, virtualEnvSet := os.LookupEnv("VIRTUAL_ENV")
+	if virtualEnvSet {
+		name = path.Join(virtualEnv, "bin", "prybar-python3")
+	}
+	err := Py_SetProgramName(name)
+	if err != nil {
+		panic(fmt.Sprintf("cannot set prybar-python3 program name to '%s': %s", name, err))
+	}
+}
 
 type Python struct{}
 


### PR DESCRIPTION
If $VIRTUAL_ENV is set, prybar-python3 will set the python program name to $VIRTUAL_ENV/bin/python. This means it will pick up the appropriate sys.path and any sitecustomize.py or usercustomize.py file present in the virtualenv.

Other packages (such as pip) use the name to find which python interpreter to invoke, so it's important that the program name resolve to an actual binary on the file system.