### PR TITLE
Better global support

### DIFF
--- a/languages/nodejs/repl.js
+++ b/languages/nodejs/repl.js
@@ -1,4 +1,4 @@
-const util = require('util');
+const util = require("util");
 const repl = require("repl");
 const path = require("path");
 const fs = require("fs");
@@ -139,11 +139,6 @@ if (process.env.PRYBAR_CODE) {
     require: module.require.bind(module),
     __dirname: path.dirname(mainPath),
     __filename: mainPath,
-
-    // These are deprecated properties and accessing them will trigger a warning.
-    // We add them manually for backward compat.
-    GLOBAL: global,
-    root: global,
   };
 
   console.log(
@@ -152,13 +147,18 @@ if (process.env.PRYBAR_CODE) {
   const context = vm.createContext(sandbox);
 
   // Adapted from https://bit.ly/2Fc4WjM
-  const globalBuiltins =
-  new Set(vm.runInNewContext('Object.getOwnPropertyNames(globalThis)'));
+  const globalBuiltins = new Set(
+    vm.runInContext("Object.getOwnPropertyNames(globalThis)", context)
+  );
+
   for (const name of Object.getOwnPropertyNames(global)) {
     // Only set properties that do not already exist as a global builtin.
     if (!globalBuiltins.has(name)) {
-      Object.defineProperty(context, name,
-                           Object.getOwnPropertyDescriptor(global, name));
+      Object.defineProperty(
+        context,
+        name,
+        Object.getOwnPropertyDescriptor(global, name)
+      );
     }
   }
   context.global = context;

--- a/test_files/global_bug.js
+++ b/test_files/global_bug.js
@@ -1,1 +1,12 @@
 console.log([] instanceof global.Array);
+console.assert(process);
+console.assert(URL);
+console.assert(URLSearchParams);
+console.assert(clearImmediate);
+console.assert(clearInterval);
+console.assert(clearTimeout);
+console.assert(setImmediate);
+console.assert(setInterval);
+console.assert(setTimeout);
+console.assert(Buffer);
+console.assert(globalThis === global);

--- a/test_files/global_bug.js
+++ b/test_files/global_bug.js
@@ -1,0 +1,1 @@
+console.log([] instanceof global.Array);

--- a/tests/nodejs/eval_code.exp
+++ b/tests/nodejs/eval_code.exp
@@ -1,4 +1,4 @@
-#!/usr/bin/expect -d
+#!/usr/bin/expect -f
 
 set timeout -1
 spawn ./prybar-nodejs -q -e 1+1

--- a/tests/nodejs/global_bug.exp
+++ b/tests/nodejs/global_bug.exp
@@ -1,0 +1,10 @@
+#!/usr/bin/expect -f
+
+set timeout -1
+spawn ./prybar-nodejs ./test_files/global_bug.js
+match_max 100000
+expect -exact "Node v12.18.3 on linux\r
+\u001b\[0m\u001b\[90mHint: hit control+c anytime to enter REPL.\[0m\r
+\u001b\[33mtrue\u001b\[39m\r
+"
+expect eof


### PR DESCRIPTION
In the current implementation, `instanceof` fails because we get classes like `Array` and `Object` from a different realm. 

With this, we only copy things that are missing from the context (and the console).

This is implementing https://github.com/replit/goval/pull/1419