### PR TITLE
Fix cross module node globals

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 stty cols 80
-stty row 20
+stty rows 20
 
 tests=$(find ./tests -printf '%P\n')
 

--- a/test_files/global_bug.js
+++ b/test_files/global_bug.js
@@ -1,4 +1,5 @@
-console.log([] instanceof global.Array);
+console.assert([] instanceof global.Array);
+console.assert([] instanceof Array);
 console.assert(process);
 console.assert(URL);
 console.assert(URLSearchParams);
@@ -10,3 +11,7 @@ console.assert(setInterval);
 console.assert(setTimeout);
 console.assert(Buffer);
 console.assert(globalThis === global);
+
+const { Object: importedObject, global: importedGlobal} = require('./global_require')
+console.assert(importedObject === Object);
+console.assert(global === importedGlobal)

--- a/test_files/global_require.js
+++ b/test_files/global_require.js
@@ -1,0 +1,4 @@
+module.exports = {
+  global,
+  Object,
+}

--- a/test_files/module_patching.js
+++ b/test_files/module_patching.js
@@ -1,0 +1,7 @@
+console.assert(module.id === '.')
+console.assert(Object.keys(module.exports).length === 0)
+console.assert(module.parent === null)
+console.assert(module.loaded === false)
+console.assert(module.children.length === 0)
+console.assert(module.filename === __filename)
+console.assert(module.filename.endsWith('/test_files/module_patching.js'));

--- a/tests/nodejs/err.exp
+++ b/tests/nodejs/err.exp
@@ -6,16 +6,16 @@ match_max 100000
 expect -exact "\[1G\[0J--> \[5G"
 send -- "x\r"
 expect -exact "x\r\r
-\u001b\[0m\u001b\[31mReferenceError: x is not defined\r
-    at repl:1:1\r
-    at Script.runInContext (vm.js:130:18)\r
-    at REPLServer.defaultEval (repl.js:435:29)\r
+\[0m\[31mReferenceError: x is not defined\r
+    at REPL1:1:1\r
+    at Script.runInThisContext (vm.js:120:18)\r
+    at REPLServer.defaultEval (repl.js:442:29)\r
     at bound (domain.js:427:14)\r
     at REPLServer.runBound \[as eval\] (domain.js:440:12)\r
-    at REPLServer.onLine (repl.js:760:10)\r
-    at REPLServer.emit (events.js:315:20)\r
+    at REPLServer.onLine (repl.js:777:10)\r
+    at REPLServer.emit (events.js:314:20)\r
     at REPLServer.EventEmitter.emit (domain.js:483:12)\r
     at REPLServer.Interface._onLine (readline.js:329:10)\r
-    at REPLServer.Interface._line (readline.js:658:8)\u001b\[0m\u001b\[1G\u001b\[0J--> \u001b\[5G"
+    at REPLServer.Interface._line (readline.js:658:8)\[0m\[1G\[0J--> \[5G"
 send -- ""
 expect eof

--- a/tests/nodejs/global_bug.exp
+++ b/tests/nodejs/global_bug.exp
@@ -1,10 +1,10 @@
 #!/usr/bin/expect -f
 
 set timeout -1
-spawn ./prybar-nodejs ./test_files/global_bug.js
+spawn ./prybar-nodejs -i ./test_files/global_bug.js
 match_max 100000
-expect -exact "Node v12.18.3 on linux\r
-\u001b\[0m\u001b\[90mHint: hit control+c anytime to enter REPL.\[0m\r
-\u001b\[33mtrue\u001b\[39m\r
-"
+expect -re {Node v\d+\.\d+.\d+ on linux}
+expect -exact "\[0m\[90mHint: hit control+c anytime to enter REPL.\[0m\r
+\[1G\[0J--> \[5G"
+send -- ""
 expect eof

--- a/tests/nodejs/module_patching.exp
+++ b/tests/nodejs/module_patching.exp
@@ -1,0 +1,10 @@
+#!/usr/bin/expect -f
+
+set timeout -1
+spawn ./prybar-nodejs -i ./test_files/global_bug.js
+match_max 100000
+expect -re {Node v\d+\.\d+.\d+ on linux}
+expect -exact "\[0m\[90mHint: hit control+c anytime to enter REPL.\[0m\r
+\[1G\[0J--> \[5G"
+send -- ""
+expect eof

--- a/tests/nodejs/run_file.exp
+++ b/tests/nodejs/run_file.exp
@@ -1,16 +1,19 @@
-#!/usr/bin/expect -d
+#!/usr/bin/expect -f
 
 set timeout -1
 spawn ./prybar-nodejs -i ./test_files/hello.js
 match_max 100000
-expect -exact "Node v12.18.3 on linux\r
-\u001b\[0m\u001b\[90mHint: hit control+c anytime to enter REPL.\[0m\r
+expect -re {Node v\d+\.\d+.\d+ on linux}
+expect -exact "\[0m\[90mHint: hit control+c anytime to enter REPL.\[0m\r
 hello\r
-\u001b\[32m'hello'\u001b\[39m\r
-\u001b\[1G\u001b\[0J--> \u001b\[5G"
-send -- "a\r"
-expect -exact "a\r\r
-\u001b\[32m'hello'\u001b\[39m\r
-\u001b\[1G\u001b\[0J--> \u001b\[5G"
+\[32m'hello'\[39m\r
+\[1G\[0J--> \[5G"
+send -- "a"
+expect -exact "\r
+\[90m'hello'\[39m\[6G\[1A"
+send -- "\r"
+expect -exact "\[1B\[2K\[1A\r\r
+\[32m'hello'\[39m\r
+\[1G\[0J--> \[5G"
 send -- ""
 expect eof


### PR DESCRIPTION
## Bug

When running with an entrypoint, the entry point's globals/context is different from required modules. This breaks some packages such as math.js that rely on instanceof. You can see the bug in the newly added asserts https://github.com/replit/prybar/commit/10c16f9e064d0ec3f522df76276c1f4f5eaf9b2e.

## Fix

Use the (current) global context when running the file, i.e. `script.runInThisContext`. This change gives us the piece of mind going forward when dealing with the global context. We still patch somethings, like adding `alert`, `confirm`, and `prompt`. We also patch the `global.module` and `global.require` to make sure the context thinks we're in the entrypoint file rather than the `repl.js` file.

I also fixed a bunch of tests that were broken.