### PR TITLE
[nodejs prompt/confirm] support left+right arrow keys

### DIFF
--- a/prybar_assets/nodejs/input-sync.js
+++ b/prybar_assets/nodejs/input-sync.js
@@ -8,13 +8,13 @@ const isTTY = isatty(process.stdin.fd);
  *
  * This is what the right arrow key translates to in raw mode.
  */
-const cursorLeft = "[C";
+const cursorRight = "[C";
 /**
  * The escape (excluding \x1b) to move the cursur left one.
  *
  * This is what the left arrow key translates to in raw mode.
  */
-const cursorRight = "[D";
+const cursorLeft = "[D";
 
 /**
  * The ASCII character sent when the tty is in raw mode and backspace is pressed.

--- a/prybar_assets/nodejs/input-sync.js
+++ b/prybar_assets/nodejs/input-sync.js
@@ -70,8 +70,40 @@ function ensureRawMode(cb) {
   return ret;
 }
 
-const delChar = "\x7f";
-const escapeClearLineRight = "\x1b[K";
+/**
+ * Handles ANSI escapes from stdin.
+ *
+ * @return {string | -1 | 1} String if the escape isn't a left arrow or right arrow.
+ * Otherwise, -1 on left arrow and 1 on right arrow
+ */
+function handleArrowKey() {
+  if (!readByteSync()) {
+    // this really shouldn't happen
+    throw new Error("Unexpected EOF");
+  }
+
+  let char = buf.toString("binary");
+
+  if (char !== "[") {
+    return `^${char}`;
+  }
+
+  // again, shouldn't happen
+  if (!readByteSync()) {
+    throw new Error("Unexpected EOF");
+  }
+
+  char = buf.toString("binary");
+
+  switch (char) {
+    case "C": // \x1b[C -> right arrow key
+      return 1;
+    case "D": // \x1b[D -> left arrow key
+      return -1;
+    default:
+      return `^[${char}`;
+  }
+}
 
 /**
  * Checks to see if the input character is what we get in raw mode for
@@ -86,6 +118,43 @@ function checkForSigs(char) {
 }
 
 /**
+ * Writes a string at an index of another string, appending as needed.
+ *
+ * @param {string} str The base string
+ * @param {string} other The new string which is being written
+ * @param {number} index The index at which the new string should start at.
+ * @return {string} str with other written at index.
+ */
+function insertAt(str, other, index) {
+  return [str.slice(0, index) + other + str.slice(index), index + other.length];
+}
+
+/**
+ * Writes a prompt,
+ *
+ * @param {string} prompt The question's prompt
+ * @param {string} current The current string (what the user has input so far)
+ * @param {number} index The index that
+ */
+function displayPromptAndStr(prompt, current, index) {
+  writeTTYOutput(
+    // reset cursor position
+    "\r" +
+      // clear the rest of the line
+      // EL (Erase in Line ): in this case, as no number is speciifed,
+      // erases everything to the right of the cursor.
+      "\x1b[K" +
+      // write the prompt
+      prompt +
+      // write the string
+      current +
+      // CHA (Cursor Horizontal Absolute): move cursor to column
+      // (starts at 1 for some reason)
+      `\x1b[${prompt.length + index + 1}G`
+  );
+}
+
+/**
  * Synchronously reads from stdin until `\n` or `\r`
  *
  * @param {string} prompt The prompt to be displayed
@@ -94,10 +163,15 @@ function checkForSigs(char) {
 function question(prompt) {
   return ensureRawMode(() => {
     let str = "";
+    let index = 0;
 
-    writeOutput(prompt);
+
+    if (!isTTY) {
+      writeOutput(prompt);
+    }
 
     for (;;) {
+      displayPromptAndStr(prompt, str, index);
       const didRead = readByteSync();
 
       if (!didRead) {
@@ -111,14 +185,32 @@ function question(prompt) {
         writeTTYOutput("\r\n");
 
         return str;
-      } else if (isTTY && char === delChar) {
-        if (str.length > 0) {
-          writeOutput("\b" + escapeClearLineRight);
-          str = str.slice(0, str.length - 1);
+      } else if (isTTY && char === "\x1b") {
+        const ret = handleArrowKey();
+
+        // if ret is a number, its the difference for the index
+        if (typeof ret === "number") {
+          // Only move the cursor if it will be in a valid position.
+          const newIndex = index + ret;
+          // the index can be equal to the strs length, if that's the case we're appending to the string.
+          if (newIndex >= 0 && newIndex <= str.length) {
+            index = newIndex;
+          }
+
+          // otherwise, the escape wasn't a left or right arrow key,
+          // meaning we got an escaped version of the code.
+        } else {
+          [str, index] = insertAt(str, ret, index);
+        }
+        // \x7f: DEL
+      } else if (isTTY && char === '\x7f') {
+        if (index > 0) {
+          index--;
+          // remove the character at the old index
+          str = str.slice(0, index) + str.slice(index + 1);
         }
       } else {
-        writeTTYOutput(buf);
-        str += char;
+        [str, index] = insertAt(str, char, index);
       }
     }
   });

--- a/tests/nodejs/prompt_tty.exp
+++ b/tests/nodejs/prompt_tty.exp
@@ -8,16 +8,28 @@ expect -exact "\[1G\[0J--> \[5G"
 send -- "prompt('abc')\r"
 expect -exact "prompt('abc')"
 expect -exact "abc> "
-send -- "helo"
-expect -exact "helo"
+send -- "makr"
+expect -exact "makr"
+
+# left arrow key
+send -- "\x1b\[D"
+expect -exact "makr"
+
 # delete
-send -- "\x7f" 
-expect -exact "\b\[K"
-send -- "lo"
-expect -exact "lo"
+send -- "\x7f"
+expect -exact "mar"
+
+# right arrow key
+send -- "\x1b\[C"
+expect -exact "mar"
+
+send -- "k"
+expect -exact "mark"
+
 send -- "\r"
 expect -exact "\r\n"
-expect -exact "'hello'"
+
+expect -exact "'mark'"
 # end of transmission
 send -- "\x04" 
 expect eof

--- a/tests/nodejs/prompt_tty_bounds.exp
+++ b/tests/nodejs/prompt_tty_bounds.exp
@@ -1,0 +1,39 @@
+#!/usr/bin/env -S expect -f
+
+set timeout -1
+spawn ./prybar-nodejs -i -q
+match_max 100000
+expect -exact "\[1G\[0J--> \[5G"
+
+send -- "prompt('abc')\r"
+expect -exact "prompt('abc')"
+expect -exact "abc> "
+
+send -- "d"
+expect -exact "abc> d"
+
+# right arrow key (index 1/1)
+send -- "\x1b\[C"
+
+send -- "e"
+expect -exact "abc> de"
+
+# left arrow key (index 2/3)
+send -- "\x1b\[D"
+
+# delete / backspace (index 1/2)
+send -- "\x7f"
+expect -exact "abc> e"
+
+# delete / backspace (index: 0/1)
+send -- "\x7f" 
+expect -exact "abc> e"
+
+# left arrow key (index 0/1)
+send -- "\x1b\[D"
+send -- "d"
+expect -exact "abc> de"
+
+# end of transmission
+send -- "\x04" 
+expect eof

--- a/tests/nodejs/prompt_tty_escapes.exp
+++ b/tests/nodejs/prompt_tty_escapes.exp
@@ -1,0 +1,34 @@
+#!/usr/bin/env -S expect -f
+
+set timeout -1
+spawn ./prybar-nodejs -i -q
+match_max 100000
+expect -exact "\[1G\[0J--> \[5G"
+
+send -- "prompt('abc')\r"
+expect -exact "prompt('abc')"
+expect -exact "abc> "
+send -- "ab"
+
+# left arrow key (index 2/2)
+send -- "\x1b\[D"
+expect -exact "abc> ab"
+
+# up arrow key (should be escaped) (index 1/2)
+send -- "\x1b\[A"
+expect -exact "abc> a^\[Ab"
+
+# right arrow key + a few deletes to clear the prompt (index 6/6)
+send -- "\x1b\[C\x7f\x7f\x7f\x7f\x7f\x7f"
+
+# random escape that doesn't exist (should be escaped)
+send -- "\x1bfake escape"
+expect -exact "abc> ^fake escape"
+
+send -- "\r"
+expect -exact "\r\n"
+expect -exact "'^fake escape'"
+
+# end of transmission
+send -- "\x04" 
+expect eof


### PR DESCRIPTION
thanks to @turbio I found that left+right arrows don't work right.  They didn't work with `readline-sync` either, but the behavior is different (ie, we'll print them back rather than let the pty escape and local echo).

This adds proper support + some tests + replaces `\x1b` with `^` for anything else - which is what the pty would do for `readline-sync`.