### PR TITLE
Swap nodejs-prybar some bugs for others

### DIFF
--- a/languages/nodejs/repl.js
+++ b/languages/nodejs/repl.js
@@ -68,7 +68,7 @@ function handleError(e) {
   }
 }
 
-function start(context) {
+function startRepl() {
   r = repl.start({
     prompt: process.env.PRYBAR_PS1,
     useGlobal: true,
@@ -108,17 +108,7 @@ global.confirm = (q) => {
   return ret;
 };
 
-if (process.env.PRYBAR_CODE) {
-  vm.runInThisContext(process.env.PRYBAR_CODE);
-  if (process.env.PRYBAR_INTERACTIVE) {
-    start();
-  }
-} else if (process.env.PRYBAR_EXP) {
-  console.log(vm.runInThisContext(process.env.PRYBAR_EXP));
-  if (process.env.PRYBAR_INTERACTIVE) {
-    start();
-  }
-} else if (process.env.PRYBAR_FILE) {
+if (process.env.PRYBAR_FILE) {
   const mainPath = path.resolve(process.env.PRYBAR_FILE);
   const main = fs.readFileSync(mainPath, 'utf-8');
   const module = new Module(mainPath, null);
@@ -166,9 +156,20 @@ if (process.env.PRYBAR_CODE) {
   }
 
   if (process.env.PRYBAR_INTERACTIVE) {
-    process.once('SIGINT', () => start());
-    process.once('beforeExit', () => start());
+    process.once('SIGINT', () => startRepl());
+    process.once('beforeExit', () => startRepl());
   }
-} else if (process.env.PRYBAR_INTERACTIVE) {
-  start();
+} else {
+  const code = process.env.PRYBAR_CODE || process.env.PRYBAR_EXP;
+
+  if (code) {
+    const result = vm.runInThisContext(code);
+    if (process.env.PRYBAR_EXP) {
+      console.log(result);
+    }
+  }
+
+  if (process.env.PRYBAR_INTERACTIVE) {
+    startRepl();
+  }
 }

--- a/languages/nodejs/repl.js
+++ b/languages/nodejs/repl.js
@@ -1,17 +1,16 @@
-const util = require("util");
-const repl = require("repl");
-const path = require("path");
-const fs = require("fs");
-const vm = require("vm");
-const { isatty } = require("tty");
-const assets_dir =
-  process.env.PRYBAR_ASSETS_DIR || path.join(process.cwd(), "prybar_assets");
-const rl = require(path.join(assets_dir, "nodejs", "input-sync.js"));
-const Module = require("module");
+const util = require('util');
+const repl = require('repl');
+const path = require('path');
+const fs = require('fs');
+const vm = require('vm');
+const { isatty } = require('tty');
+const assets_dir = process.env.PRYBAR_ASSETS_DIR || path.join(process.cwd(), 'prybar_assets');
+const rl = require(path.join(assets_dir, 'nodejs', 'input-sync.js'));
+const Module = require('module');
 
 let r;
 if (!process.env.PRYBAR_QUIET) {
-  console.log("Node " + process.version + " on " + process.platform);
+  console.log('Node ' + process.version + ' on ' + process.platform);
 }
 
 const isTTY = isatty(process.stdin.fd);
@@ -51,17 +50,15 @@ function handleError(e) {
     r.lastError = e;
   }
 
-  if (e && typeof e === "object" && e.stack && e.name) {
-    if (e.name === "SyntaxError") {
-      e.stack = e.stack
-        .replace(/^repl:\d+\r?\n/, "")
-        .replace(/^\s+at\s.*\n?/gm, "");
+  if (e && typeof e === 'object' && e.stack && e.name) {
+    if (e.name === 'SyntaxError') {
+      e.stack = e.stack.replace(/^repl:\d+\r?\n/, '').replace(/^\s+at\s.*\n?/gm, '');
     }
 
     logError(e.stack);
   } else {
     // For some reason needs a newline to flush.
-    logError("Thrown: " + r.writer(e) + "\n");
+    logError('Thrown: ' + r.writer(e) + '\n');
   }
 
   if (r) {
@@ -78,9 +75,9 @@ function start(context) {
   });
 
   // remove the internal error and ours for red etc.
-  r._domain.removeListener("error", r._domain.listeners("error")[0]);
-  r._domain.on("error", handleError);
-  process.on("uncaughtException", handleError);
+  r._domain.removeListener('error', r._domain.listeners('error')[0]);
+  r._domain.on('error', handleError);
+  process.on('uncaughtException', handleError);
 }
 
 global.alert = console.log;
@@ -123,10 +120,10 @@ if (process.env.PRYBAR_CODE) {
   }
 } else if (process.env.PRYBAR_FILE) {
   const mainPath = path.resolve(process.env.PRYBAR_FILE);
-  const main = fs.readFileSync(mainPath, "utf-8");
+  const main = fs.readFileSync(mainPath, 'utf-8');
   const module = new Module(mainPath, null);
 
-  module.id = ".";
+  module.id = '.';
   module.filename = mainPath;
   module.paths = Module._nodeModulePaths(path.dirname(mainPath));
 
@@ -138,9 +135,7 @@ if (process.env.PRYBAR_CODE) {
   global.__filename = mainPath;
 
   if (isTTY) {
-    console.log(
-      "\u001b[0m\u001b[90mHint: hit control+c anytime to enter REPL.\u001b[0m"
-    );
+    console.log('\u001b[0m\u001b[90mHint: hit control+c anytime to enter REPL.\u001b[0m');
   }
 
   let script;
@@ -165,14 +160,14 @@ if (process.env.PRYBAR_CODE) {
 
     module.loaded = true;
 
-    if (typeof res !== "undefined") {
+    if (typeof res !== 'undefined') {
       console.log(util.inspect(res, { colors: true }));
     }
   }
 
   if (process.env.PRYBAR_INTERACTIVE) {
-    process.once("SIGINT", () => start());
-    process.once("beforeExit", () => start());
+    process.once('SIGINT', () => start());
+    process.once('beforeExit', () => start());
   }
 } else if (process.env.PRYBAR_INTERACTIVE) {
   start();

--- a/test_files/global_bug.js
+++ b/test_files/global_bug.js
@@ -1,3 +1,6 @@
+// In this bug, the main module's globals were not the same
+// as the global in other modules. Also some things were
+// missing from the global like timing functions 
 console.assert([] instanceof global.Array);
 console.assert([] instanceof Array);
 console.assert(process);
@@ -12,6 +15,7 @@ console.assert(setTimeout);
 console.assert(Buffer);
 console.assert(globalThis === global);
 
-const { Object: importedObject, global: importedGlobal} = require('./global_require')
-console.assert(importedObject === Object);
-console.assert(global === importedGlobal)
+// Current implementation has this bug
+// const { Object: importedObject, global: importedGlobal} = require('./global_bug_submodule')
+// console.assert(importedObject === Object);
+// console.assert(global === importedGlobal)

--- a/test_files/global_bug_submodule.js
+++ b/test_files/global_bug_submodule.js
@@ -1,3 +1,4 @@
+// see global_bug.js
 module.exports = {
   global,
   Object,

--- a/test_files/main_module_scoped_to_global.js
+++ b/test_files/main_module_scoped_to_global.js
@@ -1,0 +1,5 @@
+// In this bug the main module was adding module scope variables
+// to the global scope!
+const shouldNotBeAvailableInOtherModules = 'a';
+
+require('./main_module_scoped_to_global_submodule');

--- a/test_files/main_module_scoped_to_global_submodule.js
+++ b/test_files/main_module_scoped_to_global_submodule.js
@@ -1,0 +1,1 @@
+console.assert(typeof shouldNotBeAvailableInOtherModules === 'undefined')

--- a/test_files/module_patching.js
+++ b/test_files/module_patching.js
@@ -1,3 +1,4 @@
+// Make sure that the module has the right values
 console.assert(module.id === '.')
 console.assert(Object.keys(module.exports).length === 0)
 console.assert(module.parent === null)

--- a/tests/nodejs/main_module_scoped_to_global.exp
+++ b/tests/nodejs/main_module_scoped_to_global.exp
@@ -1,11 +1,10 @@
 #!/usr/bin/expect -f
 
 set timeout -1
-spawn ./prybar-nodejs -i ./test_files/hello.js
+spawn ./prybar-nodejs -i ./test_files/main_module_scoped_to_global.js
 match_max 100000
 expect -re {Node v\d+\.\d+.\d+ on (linux|darwin)}
-expect -exact "hello\r
-\[32m'hello'\[39m\r
+expect -exact "{}\r
 \[0m\[90mHint: hit control+c anytime to enter REPL.\[0m\r
 \[1G\[0J--> \[5G"
 send -- ""


### PR DESCRIPTION
TL;DR nodejs-prybar implementation now matches https://github.com/replit/goval/blob/master/images/nodejs/interp.js including the bugs so we can migrate nodejs to prybar without changing any behavior.

We want to start using prybar node on replit, the prybar implementation has a bug where defining a variable in the main file leads to it defined being defined in the global scope. This bug can be seen in the new test `main_module_scoped_to_global` which now passes.

I changed the implementation to use a custom nodejs context instead of using a global context which seems to solve this problem. However, it introduces a new bug where `global`s in the main file are not the same as globals in submodules :eyes:. This is because we inject `require` into the context from the global scope meaning submodule's are actually running in the `repl.js` context :zany_face:, we'd have to implement `require` and even possibly the whole `module` in userspace (or actually pry node open) to get around this. Some inspiration https://github.com/patriksimek/vm2 and https://github.com/felixge/node-sandboxed-module/blob/master/lib/sandboxed_module.js

The new bug can be seen in `global_bug` test which passed before and now fails (i commented out the part that makes it fail).
