### PR TITLE
Ensure sqlite shared library is compiled and included in Nix derivation

### DIFF
--- a/build-prybar.nix
+++ b/build-prybar.nix
@@ -30,6 +30,11 @@ buildGoModule {
 
     ${bash}/bin/bash ./scripts/inject.sh ${language}
     go generate ./languages/${language}/main.go
+
+    if [[ -f "languages/${language}/compile" ]]; then
+      patchShebangs languages/${language}/compile
+      languages/${language}/compile;
+    fi
   '';
 
   # The test file expect the binary to be in the current directory rather than bin


### PR DESCRIPTION
Noticed sqlite was missing a shared library that is supposed to be LD_PRELOAD'd into the sqlite cli. This compiles it so it ends up in the `prybar_assets` directory in the final built Nix derivation.