### PR TITLE
Fix elisp prybar asset dir lookup when bundled with Nix

### DIFF
--- a/languages/elisp/main.go
+++ b/languages/elisp/main.go
@@ -25,7 +25,12 @@ func Execute(config *utils.Config) {
 	}
 
 	runDir := filepath.Dir(execPath)
-	replPath := filepath.Join(runDir, "prybar_assets", "elisp", "repl.el")
+
+	prybarAssetDir := os.Getenv("PRYBAR_ASSETS_DIR")
+	if prybarAssetDir == "" {
+		prybarAssetDir = filepath.Join(runDir, "prybar_assets")
+	}
+	replPath := filepath.Join(prybarAssetDir, "elisp", "repl.el")
 
 	args = append(
 		args, "emacs", "-nw", "-Q", "--load", replPath,


### PR DESCRIPTION
The elisp prybar was trying to get `repl.el` from the wrong directory. Now it relies on `PRYBAR_ASSETS_DIR` as set by Nix.

:thinking: there's probably a better way to do this than an env var...