### PR TITLE
Fix wrong prybar asset dir for sqlite

### DIFF
--- a/languages/sqlite/main.go
+++ b/languages/sqlite/main.go
@@ -42,7 +42,12 @@ func preloadQuietLib(env []string) []string {
 		panic(err)
 	}
 	runDir := filepath.Dir(execPath)
-	libPath := filepath.Join(runDir, "prybar_assets", "sqlite", "patch.so")
+
+	prybarAssetDir := os.Getenv("PRYBAR_ASSETS_DIR")
+	if prybarAssetDir == "" {
+		prybarAssetDir = filepath.Join(runDir, "prybar_assets")
+	}
+	libPath := filepath.Join(prybarAssetDir, "sqlite", "patch.so")
 	return append(env, []string{"LD_PRELOAD=" + libPath, "PRYBAR_QUIET=1"}...)
 }
 


### PR DESCRIPTION
Same as https://github.com/replit/prybar/pull/80 but for sqlite

Test plan:
Run `nix run .#prybar-sqlite -- -q -i main.sql` with an example `main.sql`

It doesn't complain about bad path to LD preload lib