### PR TITLE
Ensure exit codes (where applicable)

### DIFF
--- a/languages/julia/main.go
+++ b/languages/julia/main.go
@@ -37,10 +37,11 @@ func (p Julia) Eval(code string) {
 	C.eval(cstr)
 }
 
-func (p Julia) EvalFile(file string, args []string) {
+func (p Julia) EvalFile(file string, args []string) int {
 	cstr := C.CString(file)
-	C.eval_file(cstr)
+	code := C.eval_file(cstr)
 	C.free(unsafe.Pointer(cstr))
+	return int(code)
 }
 
 func (p Julia) REPL() {

--- a/languages/julia/pry.h
+++ b/languages/julia/pry.h
@@ -107,7 +107,7 @@ void cleanup() { jl_atexit_hook(0); }
 
 void eval(const char *str) { jl_eval_string(str); }
 
-void eval_file(const char *path) { exec_program(path); }
+int eval_file(const char *path) { return exec_program(path); }
 
 void run_repl() { fancy_repl(); }
 

--- a/languages/lua/main.go
+++ b/languages/lua/main.go
@@ -49,11 +49,11 @@ func (p Lua) Eval(code string) {
 	C.pry_eval(ccode)
 }
 
-func (p Lua) EvalFile(file string) {
+func (p Lua) EvalFile(file string, args []string) int {
 	cfile := C.CString(file)
 	defer C.free(unsafe.Pointer(cfile))
 
-	C.pry_eval_file(cfile)
+	return int(C.pry_eval_file(cfile))
 }
 
 func (p Lua) REPL() {

--- a/languages/lua/pry.c
+++ b/languages/lua/pry.c
@@ -13,4 +13,4 @@ void pry_eval(const char *code) { dostring(pry_L, code, "<eval>"); }
 
 void pry_do_repl(void) { dotty(pry_L); }
 
-void pry_eval_file(char *file) { handle_script(pry_L, &file, 0); }
+int pry_eval_file(char *file) { return handle_script(pry_L, &file, 0); }

--- a/languages/lua/pry.h
+++ b/languages/lua/pry.h
@@ -4,7 +4,7 @@ extern lua_State *pry_L;
 
 const char *pry_get_version(void);
 void pry_eval(const char *code);
-void pry_eval_file(char *file);
+int pry_eval_file(char *file);
 void pry_do_repl(void);
 
 // from the lua repl lib (lua.c)

--- a/languages/nodejs/repl.js
+++ b/languages/nodejs/repl.js
@@ -73,9 +73,13 @@ const isTTY = isatty(process.stdin.fd);
 // Red errors (if stdout is a TTY)
 function logError(msg) {
   if (isTTY) {
-    process.stdout.write(`\u001b[0m\u001b[31m${msg}\u001b[0m`);
+    process.stderr.write(`\u001b[0m\u001b[31m${msg}\u001b[0m`);
   } else {
-    process.stdout.write(msg);
+    process.stderr.write(msg);
+  }
+
+  if (!msg.endsWith('\n')) {
+    process.stderr.write('\n');
   }
 
   if (!msg.endsWith('\n')) {
@@ -179,6 +183,10 @@ if (process.env.PRYBAR_CODE) {
     runCode(process.env.PRYBAR_CODE, isInterractive);
   } catch (err) {
     handleError(err);
+
+    if (!isInterractive) {
+      process.exit(1)
+    }
   }
 
   if (isInterractive) {
@@ -189,12 +197,20 @@ if (process.env.PRYBAR_CODE) {
     console.log(runCode(process.env.PRYBAR_EXP, false));
   } catch (err) {
     handleError(err);
+
+    if (!isInterractive) {
+      process.exit(1)
+    }
   }
 } else if (process.env.PRYBAR_FILE) {
   try {
     runModule(process.env.PRYBAR_FILE, isInterractive);
   } catch (err) {
     handleError(err);
+
+    if (!isInterractive) {
+      process.exit(1)
+    }
   }
 
   if (isInterractive) {

--- a/languages/python2/main.go
+++ b/languages/python2/main.go
@@ -38,7 +38,7 @@ func (p Python) EvalExpression(code string) string {
 	return C.GoString(C.pry_eval(ccode, C.Py_eval_input))
 }
 
-func (p Python) EvalFile(file string, args []string) {
+func (p Python) EvalFile(file string, args []string) int {
 	handle := C.stdin
 	cfile := C.CString(file)
 	defer C.free(unsafe.Pointer(cfile))
@@ -53,7 +53,14 @@ func (p Python) EvalFile(file string, args []string) {
 
 	argv := C.CString(file + "\x00" + strings.Join(args, "\x00"))
 	defer C.free(unsafe.Pointer(argv))
-	C.pry_eval_file(handle, cfile, C.int(len(args)+1), argv)
+	status := C.pry_eval_file(handle, cfile, C.int(len(args)+1), argv)
+
+	// exitCode is a negative number if an error occured
+	if status != 0 {
+		return 1
+	}
+
+	return 0
 }
 
 func (p Python) REPLLikeEval(code string) {

--- a/languages/python2/pry_python2.c
+++ b/languages/python2/pry_python2.c
@@ -1,6 +1,6 @@
 #include "pry_python2.h"
 
-void pry_eval_file(FILE *f, const char *file, int argn, const char *argv)
+int pry_eval_file(FILE *f, const char *file, int argn, const char *argv)
 {
     const char *xargv[argn + 1];
     const char *ptr = argv;
@@ -11,7 +11,7 @@ void pry_eval_file(FILE *f, const char *file, int argn, const char *argv)
     }
     xargv[argn] = NULL;
     PySys_SetArgvEx(argn, xargv, 1);
-    PyRun_AnyFile(f, file);
+    return PyRun_AnyFile(f, file);
 }
 
 const char *pry_eval(const char *code, int start)

--- a/languages/python2/pry_python2.h
+++ b/languages/python2/pry_python2.h
@@ -1,5 +1,5 @@
 #include <Python.h>
 
-void pry_eval_file(FILE *f, const char *file, int argn, const char *argv);
+int pry_eval_file(FILE *f, const char *file, int argn, const char *argv);
 const char *pry_eval(const char *code, int start);
 void pry_set_prompts(const char *ps1, const char *ps2);

--- a/languages/python3/pry_python3.h
+++ b/languages/python3/pry_python3.h
@@ -1,6 +1,8 @@
 #include <Python.h>
 
-void pry_eval_file(FILE *f, const char *file, int argn, const char *argv);
+int pry_eval_file(FILE *f, const char *file, int argn, const char *argv);
 const char *pry_eval(const char *code, int start);
 void pry_set_prompts(const char *ps1, const char *ps2);
-void pymain_run_interactive_hook(void);
+int pymain_run_interactive_hook(int *exitcode);
+int pymain_err_print(int *exitcode_p);
+PyAPI_FUNC(int) _Py_HandleSystemExit(int *exitcode_p);

--- a/languages/ruby/main.go
+++ b/languages/ruby/main.go
@@ -34,10 +34,10 @@ func (p Ruby) EvalExpression(code string) string {
 	return C.GoString(res)
 }
 
-func (p Ruby) EvalFile(file string, args []string) {
+func (p Ruby) EvalFile(file string, args []string) int {
 	cfile := C.CString(file)
 	defer C.free(unsafe.Pointer(cfile))
-	C.pry_eval_file(cfile)
+	return int(C.pry_eval_file(cfile))
 }
 
 func (p Ruby) REPL() {

--- a/languages/ruby/pry_ruby.c
+++ b/languages/ruby/pry_ruby.c
@@ -36,7 +36,7 @@ char *pry_eval(const char *code)
     }
 }
 
-void pry_eval_file(const char *file)
+int pry_eval_file(const char *file)
 {
     char *options[] = {"ruby", file};
     void *node = ruby_options(2, options);
@@ -46,4 +46,6 @@ void pry_eval_file(const char *file)
     {
         state = ruby_exec_node(node);
     }
+
+    return state;
 }

--- a/languages/ruby/pry_ruby.h
+++ b/languages/ruby/pry_ruby.h
@@ -4,5 +4,5 @@
 void pry_open();
 const char *pry_ruby_version();
 char *pry_eval(const char *code);
-void pry_eval_file(const char *file);
+int pry_eval_file(const char *file);
 

--- a/languages/tcl/main.go
+++ b/languages/tcl/main.go
@@ -63,7 +63,7 @@ func (p *Tcl) eval(code string) string {
 	return ""
 }
 
-func (p *Tcl) EvalFile(file string, args []string) {
+func (p *Tcl) EvalFile(file string, args []string) int {
 	cfile := C.CString(file)
 	defer C.free(unsafe.Pointer(cfile))
 
@@ -72,7 +72,10 @@ func (p *Tcl) EvalFile(file string, args []string) {
 	if status != C.TCL_OK {
 		errstr := C.GoString(C.Tcl_GetStringResult(p.interp))
 		fmt.Fprintf(os.Stderr, "error: %s\n", errstr)
+		return int(status)
 	}
+
+	return 0
 }
 
 func (p *Tcl) Eval(code string) {
@@ -86,4 +89,5 @@ func (p *Tcl) EvalExpression(code string) string {
 func (p *Tcl) Close() {
 	C.Tcl_Finalize()
 }
+
 var Instance = &Tcl{}

--- a/utils/language.go
+++ b/utils/language.go
@@ -25,7 +25,7 @@ type PluginEvalExpression interface {
 
 type PluginEvalFile interface {
 	PluginBase
-	EvalFile(file string, args []string)
+	EvalFile(file string, args []string) int
 }
 
 type PluginREPL interface {
@@ -80,16 +80,17 @@ func (lang Language) REPLLikeEval(code string) {
 	}
 }
 
-func (lang Language) EvalFile(file string, args []string) {
+func (lang Language) EvalFile(file string, args []string) int {
 	pef, ok := lang.ptr.(PluginEvalFile)
 	if ok {
-		pef.EvalFile(file, args)
+		return pef.EvalFile(file, args)
 	} else {
 		dat, err := ioutil.ReadFile(file)
 		if err != nil {
 			panic(err)
 		}
 		lang.Eval(string(dat))
+		return 0
 	}
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -58,12 +58,17 @@ func DoCli(p PluginBase) {
 	if config.Exp != "" {
 		lang.EvalAndTryToPrint(config.Exp)
 	}
+
 	if len(config.Args) > 0 {
 		if _, err := os.Stat(config.Args[0]); os.IsNotExist(err) {
 			fmt.Println("No such file:", config.Args[0])
 			os.Exit(2)
 		} else {
-			lang.EvalFile(config.Args[0], config.Args[1:])
+			exitCode := lang.EvalFile(config.Args[0], config.Args[1:])
+			// TODO: Maybe log if exitCode is non-zero and interractive is true?
+			if exitCode != 0 && !(config.Interactive || config.OurInteractive) {
+				os.Exit(exitCode)
+			}
 		}
 	}
 
@@ -71,6 +76,7 @@ func DoCli(p PluginBase) {
 		lang.SetPrompts(config.Ps1, config.Ps2)
 		lang.REPL()
 	} else if config.OurInteractive {
+		fmt.Println("interactive")
 		lang.InternalREPL()
 	}
 }


### PR DESCRIPTION
This changes a few things:

1. When not running with `-i` or `-I`, the languages which weren't already doing so will exit with the appropriate exit codes.
2. Updated the python3 functions which were copied from the python source code to match the current supported version.  Note that the functions we copied from python 3.8 do not match v3.9 and **will need to be updated for future python versions.**
3. NodeJS now logs errors to `stderr` instead of stdout.  This isn't strictly needed, but for iotesting its a bit neater + its more consistent with native node and other languages.



