### PR TITLE
Fix broken test for nodejs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
 
           prybar-nodejs = buildPrybar {
             language = "nodejs";
-            binaries = [ pkgs.nodejs ];
+            binaries = [ pkgs.nodejs-12_x ];
           };
 
           prybar-python2 = buildPrybar {


### PR DESCRIPTION
Updating nixpkgs updated Node to a new major version in the Nix check phase which broken a test. This pins us to v12.

Note: This is just the version of Node used to run the test, prybar still uses whatever node is in the environment.