### PR TITLE
[nodejs] don't run code twice on error

### DIFF
--- a/prybar_assets/nodejs/module-context-hook.js
+++ b/prybar_assets/nodejs/module-context-hook.js
@@ -166,8 +166,8 @@ function runModule(moduleName, isInteractive) {
       let compiled;
 
       try {
-        hookedFileSource = code;
-        compiled = compile(code + interactiveFooterSnippet, fileName);
+        // validate that the module has valid syntax without executing the code
+        vm.compileFunction(code, moduleVariables);
       } catch (err) {
         // this error is probably unrelated to our added code
         // and should fail to compile again.
@@ -180,9 +180,14 @@ function runModule(moduleName, isInteractive) {
         console.warn(
           'running without interp',
           err,
-          'please submit a bug report.',
+          'please submit a bug report.'
         );
+
+        return compiled;
       }
+
+      hookedFileSource = code;
+      compiled = compile(code + interactiveFooterSnippet, fileName);
 
       return compiled;
     });
@@ -214,7 +219,7 @@ function runCode(code, isInterractive) {
       fileSource,
       // lie to the `compile` function about the file we're compiling
       // so calls to `require` will be resolved from the current directory.
-      fakeFileName,
+      fakeFileName
     );
   });
 
@@ -303,9 +308,9 @@ function getRepl() {
         new Set(
           Reflect.ownKeys(global).concat(
             Reflect.ownKeys(locals),
-            Reflect.ownKeys(ctx),
-          ),
-        ),
+            Reflect.ownKeys(ctx)
+          )
+        )
       );
     },
     // Trap for the [[GetOwnProperty]] (used by the Object.getOwnPropertyDescriptor) function
@@ -407,7 +412,7 @@ function getRepl() {
   }
 
   const kContextId = Object.getOwnPropertySymbols(repl).find(
-    (v) => v.description === 'contextId',
+    (v) => v.description === 'contextId'
   );
 
   repl.context.repl = repl;


### PR DESCRIPTION
https://app.asana.com/0/0/1202058950801330

To avoid confusing errors in stack traces, we would re-run compiled code if it error-ed to avoid syntax errors on lines that don't  exist.

This caused the following code to run twice since "compile" in nodejs is "compile and run."
```js
console.log('hi');
throw new Error('blah');
```

Since the only errors we care about are syntax errors, we'll instead use `compileFunction` from `vm` to validate the syntax - if it fails, we'll compile the original code (to get an appropriate error); otherwise we'll compile the  code with our footer (at this point we don't care if the code fails since the callsites will be on the correct lines).
