### PR TITLE
Add .toUpperCase() instead of an OR statement

### DIFF
--- a/prybar_assets/nodejs/input-sync.js
+++ b/prybar_assets/nodejs/input-sync.js
@@ -278,7 +278,7 @@ function keyInYNStrict(prompt) {
       if (char.match(/[yn]/i)) {
         writeTTYOutput(`${char}\r\n`);
 
-        return char === "y" || char === "Y";
+        return char.toUpperCase() === "Y";
       }
     }
   });


### PR DESCRIPTION
Honestly I don't know why this was did, but if there is a good reason ya'll did this then you can close this