### PR TITLE
[Lua] [sus] Fix intermittent Lua crashes

### DIFF
--- a/languages/lua/lua.c
+++ b/languages/lua/lua.c
@@ -93,12 +93,9 @@ static void print_version(void) {
   l_message(NULL, LUA_RELEASE "  " LUA_COPYRIGHT);
 }
 
-static int getargs(lua_State *L, char **argv, int n) {
+static int getargs(lua_State *L, char **argv, int n, int argc) {
   int narg;
   int i;
-  int argc = 0;
-  while (argv[argc])
-    argc++;              /* count total number of arguments */
   narg = argc - (n + 1); /* number of arguments to the script */
   luaL_checkstack(L, narg + 3, "too many arguments to script");
   for (i = n + 1; i < argc; i++)
@@ -230,7 +227,7 @@ void dotty(lua_State *L) {
 int handle_script(lua_State *L, char **argv, int n) {
   int status;
   const char *fname;
-  int narg = getargs(L, argv, n); /* collect arguments */
+  int narg = getargs(L, argv, n, 1); /* collect arguments */
   lua_setglobal(L, "arg");
   fname = argv[n];
   if (strcmp(fname, "-") == 0 && strcmp(argv[n - 1], "--") != 0)

--- a/languages/lua/lua_test.go
+++ b/languages/lua/lua_test.go
@@ -10,9 +10,6 @@ func TestLuaStuff(t *testing.T) {
 	lua.Open()
 	lua.Version()
 	for i := 0; i < 100; i++ {
-		// wrap in goroutine for instant fun crashing behavior!
-		// go func() {
 		lua.EvalFile("testdata/test.lua", make([]string, 0))
-		// }()
 	}
 }

--- a/languages/lua/lua_test.go
+++ b/languages/lua/lua_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+)
+
+// Mostly a debugging aid, not sure if it'll actually fail if something goes wrong
+func TestLuaStuff(t *testing.T) {
+	var lua Lua
+	lua.Open()
+	lua.Version()
+	lua.EvalFile("testdata/test.lua", make([]string, 0))
+}

--- a/languages/lua/lua_test.go
+++ b/languages/lua/lua_test.go
@@ -9,5 +9,10 @@ func TestLuaStuff(t *testing.T) {
 	var lua Lua
 	lua.Open()
 	lua.Version()
-	lua.EvalFile("testdata/test.lua", make([]string, 0))
+	for i := 0; i < 100; i++ {
+		// wrap in goroutine for instant fun crashing behavior!
+		// go func() {
+		lua.EvalFile("testdata/test.lua", make([]string, 0))
+		// }()
+	}
 }

--- a/languages/lua/testdata/test.lua
+++ b/languages/lua/testdata/test.lua
@@ -1,0 +1,1 @@
+print("Hello, World!")

--- a/test.lua
+++ b/test.lua
@@ -1,1 +1,0 @@
-print("Hello, World!")

--- a/test.lua
+++ b/test.lua
@@ -1,0 +1,1 @@
+print("Hello, World!")


### PR DESCRIPTION
Why
===

_Describe what prompted you to make this change, link relevant resources: Asana tasks, Canny report, Slack discussions...etc_
Fixes intermittent Lua crashes described in [this asana task](https://app.asana.com/0/home/1202058573462454/1202272228116397)

I *believe* this crash is triggered due to reading garbage, and only intermittently possibly because of different allocation patterns.

What changed
============

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_
- Pass in number of arguments instead of determining them based on the given array shape (which starts reading garbage)
    - This is hardcoded to `1` (the filename) and `getargs` only appears to be used from one place. Do we ever actually have any arguments? Why does this function even exist then? What is going on with all the weird pointer logic and indecipherable variable names in it?
- Add a test useful for manual debugging

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_

- Create Lua repl and run it a bunch of times
- See below error (about 1 time in 10)
- Apply this patch
- Run Lua repl a bunch more time
- No more errors!

```
fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x203000 pc=0x7f8bd507c5d1]

runtime stack:
runtime.throw({0x4e5fb3, 0x24a9c00})
    runtime/panic.go:1198 +0x71
runtime.sigpanic()
    runtime/signal_unix.go:719 +0x396

goroutine 1 [syscall, locked to thread]:
runtime.cgocall(0x4b8c60, 0xc00005bda0)
    runtime/cgocall.go:156 +0x5c fp=0xc00005bd78 sp=0xc00005bd40 pc=0x40653c
main._Cfunc_pry_eval_file(0x24abb20)
    _cgo_gotypes.go:183 +0x48 fp=0xc00005bda0 sp=0xc00005bd78 pc=0x4b7da8
main.Lua.EvalFile({}, {0x7ffe557231c1, 0x4ccea0}, {0x4d4120, 0x492301, 0x5d0690})
    github.com/replit/prybar/languages/lua/main.go:56 +0x5e fp=0xc00005bde0 sp=0xc00005bda0 pc=0x4b84be
main.(*Lua).EvalFile(0x5d0690, {0x7ffe557231c1, 0x5d0690}, {0xc000012230, 0x0, 0xc00010ad00})
    <autogenerated>:1 +0x45 fp=0xc00005be18 sp=0xc00005bde0 pc=0x4b8905
github.com/replit/prybar/utils.Language.EvalFile({{0x504410, 0x5d0690}, {0x7ffe557231ab, 0xc00005e100}}, {0x7ffe557231c1, 0x8}, {0xc000012230, 0x0, 0x0})
    github.com/replit/prybar/utils/language.go:86 +0xa2 fp=0xc00005be78 sp=0xc00005be18 pc=0x4b6d62
github.com/replit/prybar/utils.DoCli({0x504410, 0x5d0690})
    github.com/replit/prybar/utils/utils.go:67 +0x2e8 fp=0xc00005bf60 sp=0xc00005be78 pc=0x4b7608
main.main()
    github.com/replit/prybar/languages/lua/generated_launch.go:7 +0x27 fp=0xc00005bf80 sp=0xc00005bf60 pc=0x4b7827
runtime.main()
    runtime/proc.go:255 +0x227 fp=0xc00005bfe0 sp=0xc00005bf80 pc=0x436d87
runtime.goexit()
    runtime/asm_amd64.s:1581 +0x1 fp=0xc00005bfe8 sp=0xc00005bfe0 pc=0x462e61
repl process died unexpectedly: exit status 2
```

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
