### PR TITLE
Add prettier locally in the nodejs folder.

### DIFF
--- a/prybar_assets/nodejs/package.json
+++ b/prybar_assets/nodejs/package.json
@@ -2,5 +2,9 @@
     "name": "@replit/prybar-assets",
     "dependencies": {
         "@replit/node-fetch": "^3.1.0"
+    },
+    "prettier": {
+        "trailingComma": "all",
+        "singleQuote": true
     }
 }


### PR DESCRIPTION
I did not add this to the `devDependencies` because the `node_modules` folder is vendored in its entirety here. Prefer #97 over this if we'd prefer to hit every file in the repo.

I did confirm that at least VSCode with prettier installed automatically runs prettier with this config. element present, even if it isn't local/listed in the dev. dependencies.