### PR TITLE
Support ocaml-compiler-libs v0.12.4

### DIFF
--- a/languages/ocaml/repl.ml
+++ b/languages/ocaml/repl.ml
@@ -108,7 +108,7 @@ let _ =
         then Filename.concat Filename.current_dir_name name
         else name
       in
-      use_silently ppf explicit_name
+      use_silently ppf (String explicit_name)
 
     let loop ppf =
       Clflags.debug := true ;


### PR DESCRIPTION
As of ocaml-compiler-libs v0.12.4 (required by `repl.ml`), module
`Toploop` signature includes this:
```ocaml
    type input = Stdin | File of string | String of string
    val use_silently : Format.formatter -> input -> bool
```

This broke the way `use_silently` was used, line 111 (see issue #118)

This change fixes this.
