### PR TITLE
fix(docs): correct typo 'an ready to go' to 'and ready to go'

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Alternately, you can use the nix shell. Enter
 nix develop
 ```
 
-to drop into a shell that has all dependencies installed an ready to go.
+to drop into a shell that has all dependencies installed and ready to go.
 
 If you don't have nix yet, install that: https://nixos.org/
 


### PR DESCRIPTION
Updated documentation to fix a small typo. Changed 'an ready to go' to 'and ready to go' for grammatical accuracy.